### PR TITLE
Updated Fullscreen Ads Refresh issue

### DIFF
--- a/src/plugin/runtime.js
+++ b/src/plugin/runtime.js
@@ -467,7 +467,7 @@ cr.plugins_.CJSAds = function(runtime)
 		CocoonJS["Ad"]["refreshBanner"]();
 	};
 	
-	Acts.prototype.RefreshFullScreen = function ()
+	Acts.prototype.RefreshFullscreen = function ()
 	{
 		if (!this.runtime.isCocoonJs)
 			return;


### PR DESCRIPTION
Line 470 has been changed from
Acts.prototype.RefreshFullScreen = function ()

to

Acts.prototype.RefreshFullscreen = function ()

to fix the refreshing of fullscreen ads!
